### PR TITLE
Bumb `com.google.flogger` to version `0.8`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 bytes = "1.5.0"
-flogger = "0.5.1"
+flogger = "0.8"
 grpc = "1.42.1"
 gson = "2.8.6"
 guava = "31.0.1-jre"


### PR DESCRIPTION
The previous version `0.5.1` has bugs in the `pom.xml` causing dependent gradle projects to warn about self-referencing dependencies.

```
Errors occurred while building effective model from /home/lorenz/.gradle/caches/modules-2/files-2.1/com.google.flogger/flogger/0.5.1/5b6795ae1159ff57d1820f44216f9ef7d957b7b7/flogger-0.5.1.pom:
        'dependencies.dependency.[com.google.flogger:flogger:0.5.1]' for com.google.flogger:flogger:0.5.1 is referencing itself. in com.google.flogger:flogger:0.5.1
``` 

This seems to be addressed here: https://github.com/google/flogger/issues/152