### PR TITLE
Set jvmToolchain for kotlin plugin

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -80,9 +80,15 @@ sourceSets {
 }
 
 java {
-    // see Notes section in README.md 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(17))
+    }
 }
 
 tasks.test {


### PR DESCRIPTION
resolves
```
'compileJava' task (current target is 17) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
```