### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - name: Checkout latest code
       uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     
     - name: Setup Gradle

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,6 @@
 name: Publish release
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/kastel-security/electionguard-java/security/code-scanning/1](https://github.com/kastel-security/electionguard-java/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimal required permissions for the GITHUB_TOKEN. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). Since the workflow is publishing a release artifact, it likely needs at least `contents: write` to upload release assets or publish to the repository, but if only read access is needed, use `contents: read`. As a minimal starting point, add `permissions: { contents: read }` at the top level, just after the `name` field and before `on:`. If later you determine that more permissions are needed (e.g., `contents: write`), you can adjust accordingly.

**What to change:**  
- In `.github/workflows/publish-release.yml`, add the following block after the `name` field and before the `on:` field:
  ```yaml
  permissions:
    contents: read
  ```
- No imports or additional definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
